### PR TITLE
Initial 0.11 commit based on template files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto eol=lf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# Terraform
+.terraform
+**/.terraform/*
+*.tfstate
+*.tfstate.backup
+
+# Terragrunt Cache
+.terragrunt-cache/
+
+# Don't commit unencrypted Secrets
+secrets.tfvars
+
+# OS X
+.history
+.DS_Store
+
+# IntelliJ
+.idea_modules
+*.iml
+*.iws
+*.ipr
+.idea/
+build/
+*/build/
+out/
+
+# VScode
+.vscode/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2019 Hypr NZ
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
Based on this repo: https://github.com/hyprnz/terraform-module-template

Made a change to the LICENSE file to use the way that Apache suggests to include the license rather than the whole LICENSE in the repo. I believe this is the way to incorporate the LICENSE.